### PR TITLE
ZCS-2923: Updated logic to set invalid LDAP url

### DIFF
--- a/data/genesis/zmprov/ldap/basic.rb
+++ b/data/genesis/zmprov/ldap/basic.rb
@@ -50,8 +50,7 @@ current.setup = [
 #
 current.action = [
   v(cb("set ldap_url") do
-    url = mLdapUrl.split(/\s+/).last.gsub(/-\d+/, '-foo')
-    ZMLocalconfig.new('-e', "ldap_url=#{url}").run
+    ZMLocalconfig.new('-e', "ldap_url=ldap://test.me:389").run
   end) do |mcaller, data|
    mcaller.pass = data[0] == 0
   end,


### PR DESCRIPTION
data/zmprov/ldap/basic.rb was failing on a container since it was expecting hostname in specific format. Removed the regex and updated the invalid LDAP test url.