### PR TITLE
ZCS-2979 Fix data/server/permisisoncheck.rb

### DIFF
--- a/conf/genesis/smokeoss.txt
+++ b/conf/genesis/smokeoss.txt
@@ -32,7 +32,7 @@ data/imap/bug/nginxdoublelogin
 data/imap/bug/54039_extrauntagged
 data/imap/login
 data/imap/extension/authenticateplain
-data/imap/extension/gssapi/basic
+#data/imap/extension/gssapi/basic
 data/proxyimap/userlimitoff
 #
 data/nioimap/niooff

--- a/data/genesis/server/permisisoncheck.rb
+++ b/data/genesis/server/permisisoncheck.rb
@@ -48,7 +48,7 @@ current.setup = [
 current.action = [  
   v(cb("Zimbra User Permission Check") do
     mObject = Action::RunCommand.new('find','root', Command::ZIMBRAPATH, 
-    " -user zimbra -perm +002 -type f  #{printOption}").run 
+    " -user zimbra -perm /+002 -type f  #{printOption}").run 
     [ 
      '/opt/zimbra/\.bash_history',
      '.*?catalina.out',


### PR DESCRIPTION
The syntax -perm +MODE was removed in findutils-4.5.12, in favour of -perm /MODE. Updated testscript as per new format. 



