### PR TITLE
Genesis execution on multi-node setup

### DIFF
--- a/conf/genesis/smokeossmultinode.txt
+++ b/conf/genesis/smokeossmultinode.txt
@@ -1,0 +1,23 @@
+# Genesis sanity suite execution on multinode setup
+
+# Create testsetup
+data/testsetup
+
+# IMAP sanity
+data/nioimap/nioon
+data/imap
+data/proxyimap/userlimiton
+data/imap/bug/nginxdoublelogin
+data/imap/bug/54039_extrauntagged
+data/imap/login
+data/imap/extension/authenticateplain
+#data/imap/extension/gssapi/basic
+data/proxyimap/userlimitoff
+data/nioimap/niooff
+data/imap
+data/nioimap/nioon
+
+# POP sanity
+data/pop
+#
+

--- a/data/genesis/imap/bug/duplicatefolder.rb
+++ b/data/genesis/imap/bug/duplicatefolder.rb
@@ -55,7 +55,7 @@ current.action = [
   #Normal operation
   proxy(mimap.method('create'),"blurdybloop"), 
   RenameVerify.new(mimap, "blurdybloop","Trash/bar"),   
-  v(RunCommand.new('/opt/zimbra/bin/mysql', Command::ZIMBRAUSER, '-X -e "select id,group_id,comment from zimbra.mailbox;"')) do |mcaller, data|
+  v(RunCommandOnMailbox.new('/opt/zimbra/bin/mysql', Command::ZIMBRAUSER, '-X -e "select id,group_id,comment from zimbra.mailbox;"')) do |mcaller, data|
     mcaller.pass = true 
     xmlData = REXML::Document.new(data[1])
     xmlData.elements['resultset'].elements.each do |node|
@@ -70,7 +70,7 @@ current.action = [
   v(cb("Duplicate Check") do 
     executeString = ['-e "select count(*) cnt, parent_id, name from mboxgroup', mgroupid, 
       '.mail_item where type=1 and mailbox_id=',mid, ' group by name, parent_id having cnt>1;"'].join('')
-    response = RunCommand.new('/opt/zimbra/bin/mysql', Command::ZIMBRAUSER, executeString).run  
+    response = RunCommandOnMailbox.new('/opt/zimbra/bin/mysql', Command::ZIMBRAUSER, executeString).run  
   end) do |mcaller, data|
     mcaller.pass = !data[1].include?("name")
   end 

--- a/data/genesis/imap/errorlimit.rb
+++ b/data/genesis/imap/errorlimit.rb
@@ -49,8 +49,10 @@ current.setup = [
 current.action = [  
   CreateAccount.new(testAccount.name,testAccount.password),
   
+  
   # set the default IMAP error counter
-  ZMLocalconfig.new('-e imap_max_consecutive_error=5'),
+  RunCommandOnMailbox.new('zmlocalconfig -e imap_max_consecutive_error=0'),
+  #ZMLocalconfig.new('-e imap_max_consecutive_error=5'),
   ZMMailboxdctl.new("restart"),
   #cb("wait") {sleep(15)},
   ZMMailboxdctl.waitForMailboxd(),

--- a/data/genesis/imap/extension/authzimbra.rb
+++ b/data/genesis/imap/extension/authzimbra.rb
@@ -27,15 +27,10 @@ testAccount = Model::TARGETHOST.cUser(name, Model::DEFAULTPASSWORD+'no')
 adminAccount = Model::TARGETHOST.cUser('admin', Model::DEFAULTPASSWORD)
 Net::IMAP.add_authenticator('X-ZIMBRA', XZimbraAuthenticator)
 
-if Model::TARGETHOST.proxy
-  imapPort = 7143
-else
-  imapPort = Model::IMAP
-end
-mimap = Net::IMAP.new(Model::TARGETHOST, imapPort, false)
-mimap2 = Net::IMAP.new(Model::TARGETHOST, imapPort, false)
-mimap3 = Net::IMAP.new(Model::TARGETHOST, imapPort, false)
-mimap4 = Net::IMAP.new(Model::TARGETHOST, imapPort, false)
+mimap = Net::IMAP.new(Model::TARGETHOST, *Model::TARGETHOST.imap)
+mimap2 = Net::IMAP.new(Model::TARGETHOST, *Model::TARGETHOST.imap)
+mimap3 = Net::IMAP.new(Model::TARGETHOST, *Model::TARGETHOST.imap)
+mimap4 = Net::IMAP.new(Model::TARGETHOST, *Model::TARGETHOST.imap)
 
 message = <<EOF.gsub(/\n/, "\r\n")
 Subject: hello

--- a/data/genesis/imap/extension/id.rb
+++ b/data/genesis/imap/extension/id.rb
@@ -53,7 +53,7 @@ current.action = [
       IDVerify.new(mimap, 'before login', '("x-vIa" "testclient" "nAmE" "FF" "vErSiOn" "10.13")'),
       p(mimap.method('login'),testAccount.name,testAccount.password),
       ## TODO - use log checker
-      v(RunCommand.new('tail', 'root', '-n15', File.join(Command::ZIMBRAPATH, 'log', 'mailbox.log'))) do | mcaller, data |
+      v(RunCommandOnMailbox.new('tail', 'root', '-n15', File.join(Command::ZIMBRAPATH, 'log', 'mailbox.log'))) do | mcaller, data |
         mcaller.pass = data[1].include?('via=testclient;ua=FF/10.13')
       end
     ]
@@ -64,14 +64,11 @@ current.action = [
       IDVerify.new(mimap, 'before login', '("x-vIa" "testclient" "nAmE" "FF" "vErSiOn" "10.13")'),
       p(mimap.method('login'),testAccount.name,testAccount.password),
       ## TODO - use log checker
-      v(RunCommand.new('tail', 'root', '-n15', File.join(Command::ZIMBRAPATH, 'log', 'mailbox.log'))) do | mcaller, data |
+      v(RunCommandOnMailbox.new('tail', 'root', '-n15', File.join(Command::ZIMBRAPATH, 'log', 'mailbox.log'))) do | mcaller, data |
         mcaller.pass = data[1].match(/via=FF\/10\.13,.+nginx.+ua=Zimbra/)
       end
     ]
   end,
-  
-
-  
   IDVerify.new(mimap, 'after login'),
   p(mimap.method('select'),"INBOX"),  
   IDVerify.new(mimap, 'after select'),

--- a/data/genesis/pop/errorlimit.rb
+++ b/data/genesis/pop/errorlimit.rb
@@ -50,7 +50,8 @@ current.action = [
   CreateAccount.new(testAccount.name,testAccount.password),
   
   # set the default IMAP error counter
-  ZMLocalconfig.new('-e pop3_max_consecutive_error=5'),
+  RunCommandOnMailbox.new('zmlocalconfig -e pop3_max_consecutive_error=5'),
+  #ZMLocalconfig.new('-e pop3_max_consecutive_error=5'),
   ZMMailboxdctl.new("restart"),
   ZMMailboxdctl.waitForMailboxd(),
   

--- a/data/genesis/testsetup/modmailerrorcounter.rb
+++ b/data/genesis/testsetup/modmailerrorcounter.rb
@@ -42,8 +42,8 @@ current.action = [
   # change number of consecutive errors allowed in IMAP and POP3 to infinity
   # for testing purpose only
   # see bug #67663 and bug #51171
-  ZMLocalconfig.new('-e imap_max_consecutive_error=0'),
-  ZMLocalconfig.new('-e pop3_max_consecutive_error=0'),
+  RunCommandOnMailbox.new('zmlocalconfig -e imap_max_consecutive_error=0'),
+  RunCommandOnMailbox.new('zmlocalconfig -e pop3_max_consecutive_error=0'),
   ZMMailboxdctl.new("restart"),
   cb("wait") {sleep(5)},
      

--- a/src/ruby/action/zmprov.rb
+++ b/src/ruby/action/zmprov.rb
@@ -39,9 +39,9 @@ module Action # :nodoc
   class CreateAccount < Action::ZMProv
     def initialize(*arguments)
       #check to see if zimbraMailHost is supplied
-      unless(arguments.any? {|x| x == 'zimbraMailHost'})
-          arguments = arguments + ['zimbraMailHost', Model::TARGETHOST.to_s]
-      end
+      #unless(arguments.any? {|x| x == 'zimbraMailHost'})
+      #    arguments = arguments + ['zimbraMailHost', Model::TARGETHOST.to_s]
+      #end
       super('ca', *arguments)
     end
   end


### PR DESCRIPTION
Genesis execution was always done on single node setup.  As a part of HA work, there is need to execute Genesis on a multi node setup. In order to achieve that, lot of refactoring needs to be done. In the first phase, I have created a new test plan smokeossmultinode.txt that has IMAP/POP sanity tests. It has total of 260 tests out of which 250 execute without any error after the changes in current pull request.
