### PR TITLE
ZIMBRA-891/ZCS-3549 Add ability to skip testcase in Genesis

### DIFF
--- a/data/genesis/imap/extension/gssapi/basic.rb
+++ b/data/genesis/imap/extension/gssapi/basic.rb
@@ -28,6 +28,7 @@ require "action/verify"
 #
 current = Model::TestCase.instance()
 current.description = "IMAP GSSAPI"
+current.skip = true #Skip this testcase till kerberos system is set up
 
 name = 'imap'+File.basename(__FILE__,'.rb')+Time.now.to_i.to_s
 testAccount = Model::TARGETHOST.cUser(name, Model::DEFAULTPASSWORD)

--- a/data/genesis/sa-learn/basic.rb
+++ b/data/genesis/sa-learn/basic.rb
@@ -51,7 +51,7 @@ current.setup = [
 current.action = [
 
   v(SALearn.new('-h')) do |mcaller, data|
-    mcaller.pass = (data[0] == 64) && data[1].include?('Usage')
+    mcaller.pass = (data[0] == 64) && data[1].include?('SpamAssassin')
   end,
 
   v(SALearn.new('--dbpath', '/opt/zimbra/data/amavisd/.spamassassin', '--siteconfigpath', '/opt/zimbra/conf/spamassassin', '--force-expire', '--sync'))  do |mcaller, data|

--- a/data/genesis/zmdailyreport/basic.rb
+++ b/data/genesis/zmdailyreport/basic.rb
@@ -43,13 +43,12 @@ datestring = time.strftime("%Y-%m-%d")
 searchsubject = "Daily mail report for "+datestring
 name = File.expand_path(__FILE__).sub(/.*?(data\/)(genesis\/)?(zm)?/, 'zm').sub('.rb', '').gsub(/\/|\(|\)/, '')
 testAccount = Model::TARGETHOST.cUser(name + time.to_i.to_s, Model::DEFAULTPASSWORD)
+adminAccount = 'admin@' + Model::DOMAIN.to_s
 
 #
 # Setup
 #
 current.setup = [
-
-
 ]
 #
 # Execution
@@ -75,7 +74,7 @@ current.action = [
   #Wait a bit for system to send mail 
   WaitQueue.new,    
 
-  v(ZMSoap.new('-z', '-m', 'admin@`zmhostname`', 'SearchRequest/query=in:inbox')) do |mcaller, data|
+  v(ZMSoap.new('-z', '-m', adminAccount, 'SearchRequest/query=in:inbox')) do |mcaller, data|
     mcaller.pass = data[0] == 0 && data[1].include?('SearchResponse') &&
                    data[1].include?(searchsubject)
   end,
@@ -103,9 +102,7 @@ current.action = [
 #
 
 current.teardown = [
-
 ]
-
 
 if($0 == __FILE__)
   require 'engine/simple'

--- a/src/ruby/model/testbed.rb
+++ b/src/ruby/model/testbed.rb
@@ -113,5 +113,6 @@ module Model # :nodoc
   YAHOOACCOUNTS = [ yahooAccount = Model::YahooImapUser.new("zimbraone@ymail.com", "test123") ]
   yahooAccount.host =  Model::Host.new('imap', 'mail.yahoo.com', false)
   DATAPATH = File.join('/opt', 'qa', 'genesis', 'data', 'TestMailRaw')
+  DOMAIN = Domain.new(HOSTINFORMATION['domain'])
 end
 

--- a/src/ruby/model/testcase.rb
+++ b/src/ruby/model/testcase.rb
@@ -18,9 +18,8 @@ require "action/filedelta"
   
     private_class_method :new
     @@current = nil
-    attr_reader :setup, :action, :description, :teardown, :verify, :monitor
-    attr_writer :setup, :action, :description, :teardown, :verify, :monitor
-    
+    attr_reader :setup, :action, :description, :teardown, :verify, :monitor, :skip
+    attr_writer :setup, :action, :description, :teardown, :verify, :monitor, :skip    
     def TestCase.instance
       unless @@current
         @@current = new
@@ -30,7 +29,7 @@ require "action/filedelta"
     end
     
     def initialize
-      @setup = @action = @description = @teardown = @verify = @monitor = nil
+      @setup = @action = @description = @teardown = @verify = @monitor = @skip = nil
     end
     
     def defaultSetup

--- a/src/ruby/runtest.rb
+++ b/src/ruby/runtest.rb
@@ -451,12 +451,17 @@ def run_loop(path, report, actionfilter = nil, testcasefilter = nil)
       else
         next if  (not File.exist?(x))
         next if (testcasefilter && (not testcasefilter.include?(x)))
-        report.testcase += 1
-        llogger = CLogger.new(x)
-        puts "Executing testcase #{x}"
-        report = processor(x, report, llogger, actionfilter)
+        load x
+        xTest = Model::TestCase.instance
+        if xTest.skip != true
+           puts "Executing testcase: #{x}"
+           report.testcase += 1
+           llogger = CLogger.new(x)
+           report = processor(x, report, llogger, actionfilter)
+        else
+           puts "Skipping testcase: #{x}"
+        end
       end
-   
     rescue
       puts $!
     end


### PR DESCRIPTION
**Issue:**
Currently there is no way to skip a testcase in Genesis.

**Fix:** 
Introduced a new flag that can be set once the TestCase instance is initialised in a testscript.

Here is how the output will look like after setting the current.skip = true for data/imap/extension/gssapi/basic.rb

```
Executing testcase: ./data/imap/extension/gssapi/setup.rb
[INFO][2017-11-08 01:03:21][genesis] [#1] ---> IMAP GSSAPI Setup
Skipping testcase: ./data/imap/extension/gssapi/basic.rb
Success. No new failures found!
```

Please note that this PR includes other minor fixes for testcripts 
