### PR TITLE
ZCS-3549 Ability to skip testcase in Genesis execution

### DIFF
--- a/data/genesis/imap/errorlimit.rb
+++ b/data/genesis/imap/errorlimit.rb
@@ -51,7 +51,7 @@ current.action = [
   
   
   # set the default IMAP error counter
-  RunCommandOnMailbox.new('zmlocalconfig -e imap_max_consecutive_error=0'),
+  RunCommandOnMailbox.new('zmlocalconfig -e imap_max_consecutive_error=5'),
   #ZMLocalconfig.new('-e imap_max_consecutive_error=5'),
   ZMMailboxdctl.new("restart"),
   #cb("wait") {sleep(15)},
@@ -97,7 +97,7 @@ current.action = [
   end,
   
   # reset counter for unlimited for other tests
-  ZMLocalconfig.new('-e imap_max_consecutive_error=0'),
+  RunCommandOnMailbox.new('zmlocalconfig -e imap_max_consecutive_error=0'),
   ZMMailboxdctl.new("restart"),
   #cb("wait") {sleep(15)},
   ZMMailboxdctl.waitForMailboxd(),

--- a/data/genesis/imap/extension/gssapi/basic.rb
+++ b/data/genesis/imap/extension/gssapi/basic.rb
@@ -28,7 +28,6 @@ require "action/verify"
 #
 current = Model::TestCase.instance()
 current.description = "IMAP GSSAPI"
-current.skip = true #Skip this testcase till kerberos system is set up
 
 name = 'imap'+File.basename(__FILE__,'.rb')+Time.now.to_i.to_s
 testAccount = Model::TARGETHOST.cUser(name, Model::DEFAULTPASSWORD)
@@ -52,13 +51,15 @@ current.setup = [
 # doesn't work for proxy yet
 # see http://www.zimbra.com/docs/ne/latest/administration_guide/ZimbraProxy.07.7.html
 #
-current.action = [  
-                  CreateAccount.new('test001@testme.com', 'whatever'),
-                  RunCommandOn.new('zqa-098.eng.vmware.com', 'kinit', 'root', '-k', 'test001@ZIMBRAQA.COM'), #this is kerberos system
-                  v(RunCommandOn.new('zqa-098.eng.vmware.com', 'gsasl', 'root', 
-                                     "--connect=%s"%Model::TARGETHOST, '-a', 'test001@testme.com', '-d')) do |mcaller, data|
-                    mcaller.pass = data[1].include?('OK LOGOUT completed')
-                  end
+current.action = [
+                  # Todo - Setup kerberos system
+  
+                  #CreateAccount.new('test001@testme.com', 'whatever'),
+                  #RunCommandOn.new('zqa-098.eng.vmware.com', 'kinit', 'root', '-k', 'test001@ZIMBRAQA.COM'), #this is kerberos system
+                  #v(RunCommandOn.new('zqa-098.eng.vmware.com', 'gsasl', 'root', 
+                  #                   "--connect=%s"%Model::TARGETHOST, '-a', 'test001@testme.com', '-d')) do |mcaller, data|
+                  #  mcaller.pass = data[1].include?('OK LOGOUT completed')
+                  #end
   
 ]
 

--- a/data/genesis/zmcleantmp/basiccheck.rb
+++ b/data/genesis/zmcleantmp/basiccheck.rb
@@ -24,8 +24,8 @@ require "action/block"
 require "action/runcommand" 
 require "action/verify"
 require "action/buildparser"
-require "#{mypath}/install/configparser"
-require "#{mypath}/cluster/rhcs/cluster"
+#require "#{mypath}/install/configparser"
+#require "#{mypath}/cluster/rhcs/cluster"
 require 'rexml/document'
 include REXML
 


### PR DESCRIPTION
Added ability to skip testcases during Genesis execution. With this change, driver script will by default search for `skiptestcases.txt`, if found not found execution happens as before. If there are testcases mentioned in `skiptestcases.txt` or with `--skip` option then those testcases will be skipped from the execution.

**Example:**

**Case 1: When testcase to skip is passed as a command line argument**

Here `./data/zmnotifyinstall/basic.rb `is passed via CL

```
root@test:/opt/qa/genesis# ruby runtestmod.rb --plan temp.txt  --skip ./data/zmnotifyinstall/basic.rb 
Setting up testbed for Genesis execution
gensis.conf found!
Using remote configuration to execute genesis...
Source machine: test
Target machine: zimbra.zcs-foss.test
skiptestcases.txt not found.
Executing testcase: ./data/zmprov/basic.rb
[INFO][2017-11-10 01:12:24][genesis] [#1] ---> Zmprov Basic test
Executing testcase: ./data/zmpython/basic.rb
[INFO][2017-11-10 01:12:31][genesis] [#2] ---> Test zmpython
Executing testcase: ./data/zmmyinit/basic.rb
[INFO][2017-11-10 01:12:44][genesis] [#3] ---> Test zmmyinit
Execution completed...
Success. No new failures found!
Skipped testcases:
./data/zmnotifyinstall/basic.rb 
```
**Case 2: When testcase to skip is passed as a command line argument and also mentioned in skiptestcases.txt.**

Here `./data/zmnotifyinstall/basic.rb`  is passed as an argument and `./data/zmpython/basic.rb` is mentioned in `skiptestcases.txt`

```
root@test:/opt/qa/genesis# ruby runtestmod.rb --plan temp.txt  --skip ./data/zmnotifyinstall/basic.rb 
Setting up testbed for Genesis execution
gensis.conf found!
Using remote configuration to execute genesis...
Source machine: test
Target machine: zimbra.zcs-foss.test
Executing testcase: ./data/zmprov/basic.rb
[INFO][2017-11-10 01:15:11][genesis] [#1] ---> Zmprov Basic test
Executing testcase: ./data/zmmyinit/basic.rb
[INFO][2017-11-10 01:15:24][genesis] [#2] ---> Test zmmyinit
Execution completed...
Success. No new failures found!
Skipped testcases:
./data/zmpython/basic.rb
./data/zmnotifyinstall/basic.rb
```

This PR contains also contains script fixes.
