### PR TITLE
ZIMBRA-890/ZCS-1396 Fix Genesis script failures

### DIFF
--- a/data/genesis/cronjob/all.rb
+++ b/data/genesis/cronjob/all.rb
@@ -31,7 +31,7 @@ current.description = "Cronjob Basic Test"
  
 include Action
 
-verificationMatrix = [
+verificationMatrixonMailbox = [
 'SHELL=/bin/bash',
 '30 2 * * * find /opt/zimbra/log/ ! -name \'zmsetup*.log\' -type f -name \'*.log?*\' -mtime +8 -exec rm {} \; > /dev/null 2>&1',
 '*/2 * * * * /opt/zimbra/libexec/zmstatuslog',
@@ -42,28 +42,25 @@ verificationMatrix = [
 '00,10,20,30,40,50 * * * * /opt/zimbra/libexec/zmlogprocess > /tmp/logprocess.out 2>&1',
 #'10 * * * * /opt/zimbra/libexec/zmgengraphs >> /tmp/gengraphs.out 2>&1',
 '30 23 * * * /opt/zimbra/libexec/zmdailyreport -m',
-'0,10,20,30,40,50 * * * * /opt/zimbra/libexec/zmqueuelog',
-'0 22 * * * /opt/zimbra/bin/zmtrainsa >> /opt/zimbra/log/spamtrain.log 2>&1',
-'45 23 * * * /opt/zimbra/bin/zmtrainsa --cleanup >> /opt/zimbra/log/spamtrain.log 2>&1',
-'20 23 * * * /opt/zimbra/common/bin/sa-learn --dbpath /opt/zimbra/data/amavisd/.spamassassin --force-expire --sync > /dev/null 2>&1 ',
-'15 5,20 * * * find /opt/zimbra/data/amavisd/tmp -maxdepth 1 -type d -name \'amavis-*\' -mtime +1 -exec rm -rf {} \; > /dev/null 2>&1',
+#Not on mailbox '0,10,20,30,40,50 * * * * /opt/zimbra/libexec/zmqueuelog',
+#Not on mailbox '0 22 * * * /opt/zimbra/bin/zmtrainsa >> /opt/zimbra/log/spamtrain.log 2>&1',
+#Not on mailbox '45 23 * * * /opt/zimbra/bin/zmtrainsa --cleanup >> /opt/zimbra/log/spamtrain.log 2>&1',
+#Not on mailbox '20 23 * * * /opt/zimbra/common/bin/sa-learn --dbpath /opt/zimbra/data/amavisd/.spamassassin --force-expire --sync > /dev/null 2>&1 ',
+#Not on mailbox '15 5,20 * * * find /opt/zimbra/data/amavisd/tmp -maxdepth 1 -type d -name \'amavis-*\' -mtime +1 -exec rm -rf {} \; > /dev/null 2>&1',
 '35 2 * * * find /opt/zimbra/log/ -type f -name \'*.out.????????????\' -mtime +8 -exec rm {} \; > /dev/null 2>&1',
 '50 2 * * * /opt/zimbra/libexec/zmcompresslogs > /dev/null 2>&1',
 '40 2 * * * /opt/zimbra/libexec/zmcleantmp',
 '*/2 * * * * /opt/zimbra/libexec/zmstatuslog > /dev/null 2>&1',
 '0 0 1 * * /opt/zimbra/libexec/zmcheckexpiredcerts -days 30 -email',
-'*/30 * * * * /opt/zimbra/libexec/zmldapmonitordb > /dev/null 2>&1',
+#Not on mailbox '*/30 * * * * /opt/zimbra/libexec/zmldapmonitordb > /dev/null 2>&1',
 '30 2 * * * find /opt/zimbra/log/ -type f -name stacktrace.\* -mtime +8 -exec rm {} \; > /dev/null 2>&1',
 '18 */2 * * * /opt/zimbra/libexec/zmcheckversion -c >> /dev/null 2>&1',
 "15 2 * * *\t/opt/zimbra/libexec/zmcomputequotausage > /dev/null 2>&1",
 "55 1 * * *\t/opt/zimbra/libexec/client_usage_report.py > /dev/null 2>&1",
 "49 0 * * 7\t/opt/zimbra/libexec/zmgsaupdate > /dev/null 2>&1",
-'45 0 * * * . /opt/zimbra/.bashrc; /opt/zimbra/libexec/zmsaupdate',
-'0 1 * * * find /opt/zimbra/data/amavisd/quarantine -type f -mtime +7 -exec rm -f {} \; > /dev/null 2>&1',
-'35 3 * * * /opt/zimbra/bin/zmcbpadmin --cleanup >/dev/null 2>&1',
-'0 1 * * 6 /opt/zimbra/bin/zmbackup -f -a all --mail-report',
-'0 1 * * 0-5 /opt/zimbra/bin/zmbackup -i --mail-report',
-'0 0 * * * /opt/zimbra/bin/zmbackup -del 1m --mail-report'
+#Not on mailbox '45 0 * * * . /opt/zimbra/.bashrc; /opt/zimbra/libexec/zmsaupdate',
+#Not on mailbox '0 1 * * * find /opt/zimbra/data/amavisd/quarantine -type f -mtime +7 -exec rm -f {} \; > /dev/null 2>&1',
+#Not on mailbox '35 3 * * * /opt/zimbra/bin/zmcbpadmin --cleanup >/dev/null 2>&1'
  ]
  
 #
@@ -77,18 +74,18 @@ current.setup = [
 # Execution
 #
 current.action = [   
-  v(RunCommand.new('crontab','zimbra', '-l')) do |mcaller, data|     
+  v(RunCommandOnMailbox.new('crontab','zimbra', '-l')) do |mcaller, data|     
     class << mcaller
       attr :failures, true
     end
     mcaller.failures = []
-    verificationMatrix.map do |x|
+    verificationMatrixonMailbox.map do |x|
        unless data[1].include?(x) 
           mcaller.failures.push({:expected => x}) 
        end
     end
     data[1].split(/\n/).select {|w| w !~ /^#.*/}.select {|w| w !~ /^$/}.map do |x|
-       unless verificationMatrix.include?(x) 
+       unless verificationMatrixonMailbox.include?(x) 
           mcaller.failures.push({:unexpected => x}) 
        end
     end

--- a/data/genesis/docs/permissions.rb
+++ b/data/genesis/docs/permissions.rb
@@ -49,8 +49,6 @@ file = ""
 # Setup
 #
 current.setup = [
-
-
 ]
 #
 # Execution
@@ -67,22 +65,12 @@ current.action = [
 
   v(RunCommand.new('ls', 'root', '-1', '/opt/zimbra/docs')) do |mcaller, data|
     if BuildParser.instance.baseBuildId =~ /NETWORK/i       
-      mcaller.pass = data[0] == 0 && (files = data[1].split(/\n/)).size == 89 && files.include?("hsm-soap-admin.txt")
+      mcaller.pass = data[0] == 0 && (files = data[1].split(/\n/)).size == 90 && files.include?("hsm-soap-admin.txt")
     else
-      mcaller.pass = data[0] == 0 && (files = data[1].split(/\n/)).size == 80 && !files.include?("hsm-soap-admin.txt")
+      mcaller.pass = data[0] == 0 && (files = data[1].split(/\n/)).size == 78 && !files.include?("hsm-soap-admin.txt")
     end
   end,
 
-  v(cb("Docs Ownership and Permission Check Directory") do
-    mObject = Action::RunCommand.new('find','root', "/opt/zimbra/docs",
-                                     "-user zimbra",
-                                     "-group zimbra",
-                                     "-type d",
-                                     "! -perm 755",
-                                     printOption).run
-  end) do |mcaller, data|
-    mcaller.pass = data[0] == 0 && !data[1].include?('/opt/zimbra/docs')
-  end,
   v(cb("Docs Ownership and Permission Check Files") do
     mObject = Action::RunCommand.new('find','root', "/opt/zimbra/docs",
                                      "-user zimbra",

--- a/data/genesis/server/filtercrash.rb
+++ b/data/genesis/server/filtercrash.rb
@@ -139,7 +139,7 @@ current.action = [
   v(cb("Send an email") {
     SendMail.new(testAccount.name,message).run
     Kernel.sleep(20)
-    response = Action::RunCommand.new('grep','root', '-i fatal /opt/zimbra/log/mailbox.log').run
+    response = Action::RunCommandOnMailbox.new('grep','root', '-i fatal /opt/zimbra/log/mailbox.log').run
     Kernel.sleep(20)
     response
   }) do |mcaller, data|

--- a/data/genesis/zmfixcalendtime/basic.rb
+++ b/data/genesis/zmfixcalendtime/basic.rb
@@ -36,7 +36,7 @@ include Action
 #
 current = Model::TestCase.instance()
 current.description = "Test zmfixcalendtime"
-
+mailbox = Model::Servers.getServersRunning("mailbox").first.to_s
 #
 # Setup
 #
@@ -57,11 +57,11 @@ current.action = [
     mcaller.pass = (data[0] == 0)
   end,
 
-  v(ZMFixcalendtime.new('-a',"admin@#{Model::TARGETHOST}", '-s',Model::TARGETHOST.to_s)) do |mcaller, data|
+  v(ZMFixcalendtime.new('-a',"admin@#{Model::TARGETHOST}", '-s', mailbox)) do |mcaller, data|
     mcaller.pass = (data[0] == 0)
   end,
 
-  v(ZMFixcalendtime.new('-a',"admin@#{Model::TARGETHOST}", '-s',Model::TARGETHOST.to_s),'--sync') do |mcaller, data|
+  v(ZMFixcalendtime.new('-a',"admin@#{Model::TARGETHOST}", '-s', mailbox),'--sync') do |mcaller, data|
     mcaller.pass = (data[0] == 0)
   end,
 
@@ -73,7 +73,7 @@ current.action = [
 #    mcaller.pass = (data[0] == 1)&& data[1].include?('Error occurred:')
 #  end,
 
-  v(ZMFixcalendtime.new('-a',"admin@#{Model::TARGETHOST}",'-s','test.wrongdomain.com')) do |mcaller, data|
+  v(ZMFixcalendtime.new('-a',"admin@#{mailbox}",'-s','test.wrongdomain.com')) do |mcaller, data|
     mcaller.pass = (data[0] == 1) && (data[1].include?('Error occurred: Unknown host:') || data[1].include?('Error occurred: connect timed out') || data[1].include?('Error occurred: Connection refused'))
   end,
 

--- a/data/genesis/zmgsautil/basic.rb
+++ b/data/genesis/zmgsautil/basic.rb
@@ -31,7 +31,7 @@ current = Model::TestCase.instance()
 current.description = "Test zmgsautil"
 
 name = File.expand_path(__FILE__).sub(/.*?(data\/)(genesis\/)?(zm)?/, 'zm').sub('.rb', '').gsub(/\/|\(|\)/, '') + Time.now.to_i.to_s
-
+mailbox = Model::Servers.getServersRunning("mailbox").first.to_s
 #
 # Setup
 #
@@ -57,7 +57,7 @@ current.action = [
   end,
 
   v(ZMGsautil.new('createAccount', '-a', 'galsync@zimbra.com', '-n', 'zimbra',
-                  '--domain', "domain.#{name}.com", '-s', Model::TARGETHOST.to_s, '-t', 'zimbra', 'p', '1d')) do |mcaller, data|
+                  '--domain', "domain.#{name}.com", '-s', mailbox, '-t', 'zimbra', 'p', '1d')) do |mcaller, data|
     mcaller.pass = data[0] == 0 && data[1].include?("Error: no such domain: domain.#{name}.com") 
   end,
   
@@ -67,13 +67,13 @@ current.action = [
   
   v(ZMGsautil.new('createAccount', '-a', 'galsync@domain.%s.com'%name, '-n', 'zimbra',
                   '--domain', "domain.#{name}.com",
-                  '-s', Model::TARGETHOST.to_s, '-t', 'zimbra', 'p', '1d')) do |mcaller, data|
+                  '-s', mailbox, '-t', 'zimbra', 'p', '1d')) do |mcaller, data|
     mcaller.pass = data[0] == 0 && data[1] =~ /^galsync@domain\.#{name}\.com\s+[\da-f\-]{36}$/
   end,
   
   v(ZMGsautil.new('createAccount', '-a', 'galsync1@domain.%s.com'%name, '-n', 'zimbra',
                   '--domain', "domain.#{name}.com",
-                  '-s', Model::TARGETHOST.to_s, '-t', 'zimbra', 'p', '1d')) do |mcaller, data|
+                  '-s', mailbox, '-t', 'zimbra', 'p', '1d')) do |mcaller, data|
     mcaller.pass = data[0] == 0 && data[1].include?("Error: email address already exists: galsync@domain.%s.com"%name) 
   end,
 =begin

--- a/data/genesis/zmjavawatch/basic.rb
+++ b/data/genesis/zmjavawatch/basic.rb
@@ -59,13 +59,13 @@ current.action = [
   
   v(cb("Checking zmmailboxdmgr Process using zmjavawatch") do
       host = Model::TARGETHOST
-      mObject = RunCommand.new('fuser /opt/zimbra/libexec/zmmailboxdmgr', 'root')
+      mObject = RunCommandOnMailbox.new('fuser /opt/zimbra/libexec/zmmailboxdmgr', 'root')
       data = mObject.run
       if data[0] == 0
         process_name = "/opt/zimbra/libexec/zmmailboxdmgr"
         oResult = data[1]
         pid = oResult.split(/\s+/)[-1].chomp.split(/\D+/).first rescue 1 #grab last of pid
-        rObject = RunCommand.new(File.join(Command::ZIMBRAPATH,'libexec','zmjavawatch'), Command::ZIMBRAUSER,"--pid=#{pid}", '-count 1')
+        rObject = RunCommandOnMailbox.new(File.join(Command::ZIMBRAPATH,'libexec','zmjavawatch'), Command::ZIMBRAUSER,"--pid=#{pid}", '-count 1')
         rResult = rObject.run
         [rResult[0],rResult[1],pid] 
       else

--- a/data/genesis/zmldappasswd/basic.rb
+++ b/data/genesis/zmldappasswd/basic.rb
@@ -32,7 +32,7 @@ current.description = "Zmldappasswd Basic test"
 include Action
 
 
-newPasswd = "test123"
+newPasswd = "zimbra"
 
 #
 # Setup
@@ -47,22 +47,7 @@ current.setup = [
 current.action = [
 
   v(ZMLdapPasswd.new('-h')) do |mcaller, data|
-    usage = ['Usage: /opt/zimbra/bin/zmldappasswd [-h] [-r] [-p] [[-c]-l] newpassword',
-             "\t-h: display this help message",
-             "\t-a: change ldap_amavis_password",
-             "\t-b: change ldap_bes_searcher_password",
-             "\t-l: change ldap_replication_password",
-             "\t-c: Update ldap_replication_password on replica. Requires -l",
-             "\t-n: change ldap_nginx_password",
-             "\t-p: change ldap_postfix_password",
-             "\t-r: change ldap_root_passwd",
-             "\tOnly one of a, l, n, p, or r may be specified",
-             "\tWithout options zimbra_ldap_password is changed",
-             "\tOption -c requires -l and must be run on a replica after",
-             "\tchanging the password on the master (using -l by itself)."
-             ].collect {|w| Regexp.escape(w)}
-    mcaller.pass = data[0] != 0 &&
-                   data[1].split(/\n/).delete_if{|w| w =~ /^\s*$/}.select {|w| w !~ /#{usage.join('|')}/}.empty?
+    mcaller.pass = data[0] != 0 && data[1].include?("Usage")
   end,
   
   v(ZMLdapPasswd.new('-b', 'zmbes-searcher')) do |mcaller, data|

--- a/src/ruby/action/zmgsautil.rb
+++ b/src/ruby/action/zmgsautil.rb
@@ -40,7 +40,7 @@ module Action # :nodoc
     attr :label, true
     def initialize(*arguments)
       super()
-      @runner = RunCommand.new(File.join(ZIMBRAPATH,'bin','zmgsautil'), ZIMBRAUSER, *arguments)
+      @runner = RunCommandOnMailbox.new(File.join(ZIMBRAPATH,'bin','zmgsautil'), ZIMBRAUSER, *arguments)
       @label = ''
       self.timeOut = 2400 #timeout to 40 minutes
     end


### PR DESCRIPTION
Fix genesis script failures for remote configuration

**Testing:**

```
root@test:/opt/qa/genesis# ruby runtest.rb --plan temp.txt 
Setting up testbed for Genesis execution
gensis.conf found!
Using remote configuration to execute genesis...
Source machine: test
Target machine: zimbra.zcs-foss.test
Executing testcase ./data/cronjob/all.rb
[INFO][2017-11-14 09:12:19][genesis] [#1] ---> Cronjob Basic Test
Executing testcase ./data/docs/permissions.rb
[INFO][2017-11-14 09:12:22][genesis] [#2] ---> Check Zimbra doc ownership and permissions 
Executing testcase ./data/server/filtercrash.rb
[INFO][2017-11-14 09:12:29][genesis] [#3] ---> Filter crash test
Executing testcase ./data/zmfixcalendtime/basic.rb
[INFO][2017-11-14 09:14:29][genesis] [#4] ---> Test zmfixcalendtime
Executing testcase ./data/zmgsautil/basic.rb
[INFO][2017-11-14 09:15:09][genesis] [#5] ---> Test zmgsautil
Executing testcase ./data/zmjavawatch/basic.rb
[INFO][2017-11-14 09:15:27][genesis] [#6] ---> Test zmjavawatch
Executing testcase ./data/zmldappasswd/basic.rb
[INFO][2017-11-14 09:16:06][genesis] [#7] ---> Zmldappasswd Basic test
Success. No new failures found!

```