### PR TITLE
Bugfix/ZCS-3940 Genesis scripts fails since mysql on separate node on zm-docker

### DIFF
--- a/data/genesis/verification/redolog.rb
+++ b/data/genesis/verification/redolog.rb
@@ -43,14 +43,14 @@ current.setup = [
 
 current.action = [  
   v(cb("Redolog check") do
-    mObject = Action::RunCommand.new(File.join(Command::ZIMBRAPATH,'bin','zmjava'),'zimbra', 
+    mObject = Action::RunCommandOnMailbox.new(File.join(Command::ZIMBRAPATH,'bin','zmjava'),'zimbra', 
     'com.zimbra.cs.redolog.util.RedoLogVerify -q redolog').run  
     mObject
   end) do |mcaller, data|  
     mcaller.pass = data[0] == 0 && !data[1].include?('error') 
   end,     
   v(cb("Redolog archive check") do
-    mObject = Action::RunCommand.new(File.join(Command::ZIMBRAPATH,'bin','zmjava'),'zimbra', 
+    mObject = Action::RunCommandOnMailbox.new(File.join(Command::ZIMBRAPATH,'bin','zmjava'),'zimbra', 
     'com.zimbra.cs.redolog.util.RedoLogVerify -q redolog/archive').run  
     mObject
   end) do |mcaller, data|  

--- a/data/genesis/zmprov/account/basic.rb
+++ b/data/genesis/zmprov/account/basic.rb
@@ -300,7 +300,7 @@ current.action = [
   v(ZMailAdmin.new('-m', testAccount, 'gaf')) do |mcaller, data|
     mcaller.pass = data[0] == 0
   end,
-  v(RunCommandOnMailbox.new(File.join(Command::ZIMBRAPATH,'bin','mysql'),Command::ZIMBRAUSER,'-e', 
+  v(RunCommandOnMysql.new(File.join(Command::ZIMBRAPATH,'bin','mysql'),Command::ZIMBRAUSER,'-e', 
                              "\"select * from zimbra.mailbox where comment like \\\"#{testAccount.name}\\\";\"")) do |mcaller, data|
     mcaller.pass = data[0] == 0 && !data[1].empty?
   end,
@@ -308,18 +308,18 @@ current.action = [
   v(ZMProv.new('da', testAccount.name)) do |mcaller, data|
     mcaller.pass = data[0] == 0
   end,
-  v(RunCommandOnMailbox.new(File.join(Command::ZIMBRAPATH,'bin','mysql'),Command::ZIMBRAUSER,'-e', 
+  v(RunCommandOnMysql.new(File.join(Command::ZIMBRAPATH,'bin','mysql'),Command::ZIMBRAUSER,'-e', 
                              "\"select * from zimbra.mailbox where comment like \\\"#{testAccount.name}\\\";\"")) do |mcaller, data|
     mcaller.pass = data[0] == 0 && data[1].empty?
   end,
-  v(RunCommandOnMailbox.new(File.join(Command::ZIMBRAPATH,'bin','mysql'),Command::ZIMBRAUSER,'-e', 
+  v(RunCommandOnMysql.new(File.join(Command::ZIMBRAPATH,'bin','mysql'),Command::ZIMBRAUSER,'-e', 
                              "\"select * from zimbra.mailbox where comment like \\\"#{testAccountTwo.name}\\\";\"")) do |mcaller, data|
     mcaller.pass = data[0] == 0 && data[1].empty?
   end,
   v(ZMProv.new('DeleteAccount', testAccountTwo.name)) do |mcaller, data|
     mcaller.pass = data[0] == 0
   end,
-  v(RunCommandOnMailbox.new(File.join(Command::ZIMBRAPATH,'bin','mysql'),Command::ZIMBRAUSER,'-e', 
+  v(RunCommandOnMysql.new(File.join(Command::ZIMBRAPATH,'bin','mysql'),Command::ZIMBRAUSER,'-e', 
                              "\"select * from zimbra.mailbox where comment like \\\"#{testAccountTwo.name}\\\";\"")) do |mcaller, data|
     mcaller.pass = data[0] == 0 && data[1].empty?
   end,

--- a/data/genesis/zmstorectl/basic.rb
+++ b/data/genesis/zmstorectl/basic.rb
@@ -40,25 +40,23 @@ current.description = "Test zmstorectl"
 # Setup
 #
 current.setup = [
-
-
 ]
+
 #
 # Execution
 #
 current.action = [
 
-#bug 47735: confirms that start and status should not return anything, hence commenting
-
+  #bug 47735: confirms that start and status should not return anything, hence commenting
   v(ZMStorectl.new, 240) do |mcaller, data|
     mcaller.pass = (data[0] == 1) && data[1].include?("/opt/zimbra/bin/zmstorectl start|stop|restart|reload|status")
   end,
 
- v(ZMStorectl.new('start'), 240) do |mcaller, data|
+  v(ZMStorectl.new('start'), 240) do |mcaller, data|
     mcaller.pass = (data[0] == 0) && !(data[1].include?("mailboxd already running") && !data[1].include?("mysqld_safe already running with pid"))
   end,
 
- v(ZMStorectl.new('start'), 240) do |mcaller, data|
+  v(ZMStorectl.new('start'), 240) do |mcaller, data|
     mcaller.pass = (data[0] == 0) && !data[1].include?("mysqld_safe already running with pid")
   end,
 
@@ -66,15 +64,14 @@ current.action = [
     mcaller.pass = (data[0] == 0)
   end,
 
-#bug 48702. Updated to catch any error while stopping.
+  #bug 48702. Updated to catch any error while stopping.
   v(ZMStorectl.new('stop'), 240) do |mcaller, data|
     mcaller.pass = (data[0] == 0) && data[1].include?('Stopping mailboxd...done.')\
-                                  && data[1].include?('Stopping mysqld... done.')\
                                   && !data[1].include?('Error')
   end,
 
   v(ZMStorectl.new('stop'), 240) do |mcaller, data|
-    mcaller.pass = (data[0] == 0)&& data[1].include?("mysqld not running: no pid in")
+    mcaller.pass = (data[0] == 0)
   end,
 
   v(ZMStorectl.new('status'), 240) do |mcaller, data|
@@ -92,26 +89,21 @@ current.action = [
   end,
 
   v(ZMStorectl.new('restart'), 240) do |mcaller, data|
-    mcaller.pass = (data[0] == 0) && data[1].include?('Stopping mysqld... done.')\
-                                  && data[1].include?('Starting mysqld...done.')\
-                                  && data[1].include?('Stopping mailboxd...done.')\
+    mcaller.pass = (data[0] == 0) && data[1].include?('Stopping mailboxd...done.')\
                                   && data[1].include?('Starting mailboxd...done.')
-
   end,
 
   v(ZMStorectl.new('status'), 240) do |mcaller, data|
     mcaller.pass = (data[0] == 0) && !data[1].include?('mailboxd')
-   end,
-
+  end,
 ]
+
 #
 # Tear Down
 #
-
 current.teardown = [
 
 ]
-
 
 if($0 == __FILE__)
   require 'engine/simple'

--- a/src/ruby/action/runcommand.rb
+++ b/src/ruby/action/runcommand.rb
@@ -87,6 +87,15 @@ module Action # :nodoc
       super(*arguments)
     end
   end
+
+  class RunCommandOnMysql< Action::RunCommand
+    def initialize(*arguments)
+      unless arguments.last.is_a?(Model::Host)
+        arguments << Model::Host.new(Model::Servers.getMysqlServer())
+      end
+      super(*arguments)
+    end
+  end
   
   class RunCommandOnLdap < Action::RunCommand
     def initialize(*arguments)

--- a/src/ruby/action/zmdiaglog.rb
+++ b/src/ruby/action/zmdiaglog.rb
@@ -40,7 +40,7 @@ module Action # :nodoc
     attr :label, true
     def initialize(*arguments)
       super()
-      @runner = RunCommand.new(File.join(ZIMBRAPATH,'libexec','zmdiaglog'), 'root', *arguments)
+      @runner = RunCommandOnMailbox.new(File.join(ZIMBRAPATH,'libexec','zmdiaglog'), 'root', *arguments)
       @label = ''
       self.timeOut = 2400 #timeout to 40 minutes
     end

--- a/src/ruby/model/servers.rb
+++ b/src/ruby/model/servers.rb
@@ -13,6 +13,7 @@ if($0 == __FILE__)
 end 
 
 require "action/zmprov"
+require "action/zmlocalconfig"
 
 include Action
 module Model # :nodoc
@@ -44,6 +45,16 @@ module Model # :nodoc
         @@serviceList[service]
       end
       
+      #returns the mysql server that is specified in the localconfig of mailbox node
+      def getMysqlServer()
+        if @@serverList.nil?
+          output = RunCommandOnMailbox.new('zmlocalconfig mysql_bind_address').run[1]
+          @@serverList = output.to_s.split('=').last.strip
+        end
+        
+        @@serverList
+      end
+     
       # returns string array of all servers
       # use targethost if want to send request from other server
       def getAllServers(targethost = Model::TARGETHOST)
@@ -71,18 +82,11 @@ module Model # :nodoc
         @@proxy = nil
         @@serviceList = {}
       end
-    
-    
     end
-  end
-  
+  end 
 end
 
 if $0 == __FILE__
   require 'test/unit'  
-  
-
 end
- 
-  
 


### PR DESCRIPTION
In some of the genesis scripts, there is a validation for mysql queries and for that these queries are run on the mailbox node, but with zm-docker mysql node is on separate node and these tests are failing because of that. Added a new method to execute queries on mysql node.

Also, in the validation scripts need to change to use `RunCommandOnMysql` instead of `RunCommandOnMailbox`. WIP
  