### PR TITLE
Bugfix/ZCS-3996 Fix data/zmdomaincertmgr/basic.rb

### DIFF
--- a/data/genesis/imap/listspecialusefalse.rb
+++ b/data/genesis/imap/listspecialusefalse.rb
@@ -55,7 +55,7 @@ trflags = [['INBOX/three', [:Haschildren]]]
 trtrflags = [['INBOX/three/three', [:Hasnochildren]]]
 otrtrflags = [["/home/#{testAccountTwo.name}/INBOX/three/three", [:Hasnochildren]]]
 
-ZMLocalconfig.new('-e', 'imap_force_special_use=FALSE').run
+RunCommandOnMailbox.new('zmlocalconfig', Command::ZIMBRAUSER, '-e imap_force_special_use=FALSE').run  
 ZMMailboxdctl.new('restart').run
 Kernel.sleep(20) #wait for imap server to be running
 mimap = Net::IMAP.new(Model::TARGETHOST, Model::IMAPSSL, true)
@@ -112,7 +112,7 @@ current.action = [
 current.teardown = [     
   p(mimap.method('logout')),
   p(mimap.method('disconnect')),
-  ZMLocalconfig.new('-u', 'imap_force_special_use'),
+  RunCommandOnMailbox.new('zmlocalconfig', Command::ZIMBRAUSER, '-u imap_force_special_use'),
   ZMMailboxdctl.new('restart'),
   Action::DeleteAccount.new(testAccount.name),
   Action::DeleteAccount.new(testAccountTwo.name)

--- a/data/genesis/imap/listspecialusetrue.rb
+++ b/data/genesis/imap/listspecialusetrue.rb
@@ -52,7 +52,8 @@ trflags = [['INBOX/three', [:Haschildren]]]
 trtrflags = [['INBOX/three/three', [:Hasnochildren]]]
 otrtrflags = [["/home/#{testAccountTwo.name}/INBOX/three/three", [:Hasnochildren]]]
 
-ZMLocalconfig.new('-e', 'imap_force_special_use=TRUE').run
+RunCommandOnMailbox.new('zmlocalconfig', Command::ZIMBRAUSER, '-e imap_force_special_use=TRUE').run  
+#ZMLocalconfig.new('-e', 'imap_force_special_use=TRUE').run
 ZMMailboxdctl.new('restart').run
 Kernel.sleep(20) #wait for imap server to be running
 mimap = Net::IMAP.new(Model::TARGETHOST, Model::IMAPSSL, true)
@@ -109,7 +110,7 @@ current.action = [
 current.teardown = [     
   p(mimap.method('logout')),
   p(mimap.method('disconnect')),
-  ZMLocalconfig.new('-u', 'imap_force_special_use'),
+  RunCommandOnMailbox.new('zmlocalconfig', Command::ZIMBRAUSER, '-u imap_force_special_use'),
   ZMMailboxdctl.new('restart'),
   Action::DeleteAccount.new(testAccount.name),
   Action::DeleteAccount.new(testAccountTwo.name)

--- a/data/genesis/zmdomaincertmgr/basic.rb
+++ b/data/genesis/zmdomaincertmgr/basic.rb
@@ -41,8 +41,6 @@ current.description = "Test zmdomaincertmgr"
 # Setup
 #
 current.setup = [
-
-
 ]
 
 hash_old = ""
@@ -99,7 +97,7 @@ current.action = [
 
    end,
    
-   v(RunCommand.new("sha256sum /opt/zimbra/conf/domaincerts/" +Model::TARGETHOST+".crt"))do |mcaller, data|
+   v(RunCommandOnMailbox.new("sha256sum /opt/zimbra/conf/domaincerts/" +Model::TARGETHOST+".crt"))do |mcaller, data|
      hash_old = data[1].split(" ")[0]
      mcaller.pass = (data[0] == 0)
    end, 
@@ -117,17 +115,17 @@ current.action = [
 
    end, 
      
-   v(RunCommand.new("sha256sum /opt/zimbra/conf/domaincerts/" +Model::TARGETHOST+".crt"))do |mcaller, data|
+   v(RunCommandOnMailbox.new("sha256sum /opt/zimbra/conf/domaincerts/" +Model::TARGETHOST+".crt"))do |mcaller, data|
       hash_new = data[1].split(" ")[0]
       mcaller.pass = (data[0] == 0 && hash_old != hash_new) # Bug 97981
    end,  
      
    
 ]
+
 #
 # Tear Down
 #
-
 current.teardown = [
     ZMProv.new('md', Model::TARGETHOST.to_s,'zimbraVirtualHostName'," ","\"\"") #unset zimbraVirtualHostName 
 ]

--- a/src/ruby/action/zmcertmgr.rb
+++ b/src/ruby/action/zmcertmgr.rb
@@ -25,7 +25,7 @@ module Action # :nodoc
   #
   # Perform zmcertmgr action
   #
-  class ZMCertmgr < Action::RunCommand
+  class ZMCertmgr < Action::RunCommandOnMailbox
 
     #
     #  Create a zmcertmgr object

--- a/src/ruby/action/zmdomaincertmgr.rb
+++ b/src/ruby/action/zmdomaincertmgr.rb
@@ -24,19 +24,14 @@ require "action/zmprov"
 require "model"
 require 'net/smtp'
 
-
-
 module Action # :nodoc
   #
   # Perform zmdomaincertmgr action.  This will invoke some zmdomaincertmgr with some arguments
-
   #
   class ZMDomaincertmgr < Action::Command
-
     #
     #  Create a zmdomaincertmgr object.
     #
-
     attr :label, true
     def initialize(*arguments)
       super()
@@ -70,5 +65,3 @@ if $0 == __FILE__
     end
   end
 end
-
-


### PR DESCRIPTION
Execute zmdomaincertmgr on mailbox. Keeping this consistent with zmcertmgr which is executed on mailbox node. 