### PR TITLE
ZCS-8016: updating commons fileupload version from 1.2.2 to 1.4

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -55,7 +55,7 @@
   <dependency org="commons-codec" name="commons-codec" rev="1.7"/>
   <dependency org="commons-io" name="commons-io" rev="1.4"/>
   <dependency org="commons-lang" name="commons-lang" rev="2.6"/>
-  <dependency org="commons-fileupload" name="commons-fileupload" rev="1.2.2"/>
+  <dependency org="commons-fileupload" name="commons-fileupload" rev="1.4"/>
   <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
   <dependency org="commons-collections" name="commons-collections" rev="3.2.2" />
   <dependency org="commons-logging" name="commons-logging" rev="1.1.1"/>


### PR DESCRIPTION
Issue:
commons-fileupload older version have vulnerabilities.

Fix:
Updating version from 1.2.2 to 1.4

Related PRs:
https://github.com/Zimbra/zm-mailbox/pull/980
https://github.com/Zimbra/zm-zcs-lib/pull/56
https://github.com/Zimbra/zm-soap-harness/pull/93
https://github.com/Zimbra/zm-taglib/pull/33
https://github.com/Zimbra/zm-clientuploader-store/pull/3
https://github.com/Zimbra/zm-clam-scanner-store/pull/2