### PR TITLE
ZCS-8013: Third party vulnerabilities in commons-compress

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -63,7 +63,7 @@
   <dependency org="org.apache.httpcomponents" name="httpasyncclient" rev="4.1.2"/>
   <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.5"/>
   <dependency org="org.apache.httpcomponents" name="httpcore-nio" rev="4.4.5"/>
-  <dependency org="org.apache.commons" name="commons-compress" rev="1.10" />
+  <dependency org="org.apache.commons" name="commons-compress" rev="1.19" />
   <dependency org="org.apache.mina" name="mina-core" rev="2.0.4"/>
   <dependency org="org.apache.curator" name="curator-recipes" rev="2.0.1-incubating" />
   <dependency org="org.apache.curator" name="curator-client" rev="2.0.1-incubating" />


### PR DESCRIPTION
Issue:  vulnerabilities in existing commons-compress jar 1.10
Fix: Upgrade commons-compress jar to the latest version 1.19

Related PRs:
https://github.com/Zimbra/zm-mailbox/pull/983
https://github.com/Zimbra/zm-zcs-lib/pull/58
https://github.com/Zimbra/zm-soap-harness/pull/95